### PR TITLE
Support distribution group

### DIFF
--- a/src/crashes/crash_manager.rs
+++ b/src/crashes/crash_manager.rs
@@ -77,7 +77,7 @@ impl CrashManager {
         let versions = VersionListParser::versions(&latest_version_json).unwrap();
         let latest_version = match distribution_group {
             Some(group) => VersionList::latest_version_of_distribution_group(versions, group),
-            None        => VersionList::latest_version(versions)
+            None => VersionList::latest_version(versions),
         };
 
         match latest_version {

--- a/src/crashes/crash_manager.rs
+++ b/src/crashes/crash_manager.rs
@@ -18,7 +18,7 @@ impl CrashManager {
     /// #
     /// // api is a mock that returns 2 crashes
     /// let manager = CrashManager{};
-    /// let report = manager.crash_list(&api, "org", "app", Some("1.2.3".to_string())).unwrap();
+    /// let report = manager.crash_list(&api, "org", "app", Some("1.2.3".to_string()), None).unwrap();
     ///
     /// assert_eq!(report.crash_list.crashes.len(), 2);
     /// assert_eq!(report.version, "1.2.3");

--- a/src/crashes/crash_manager.rs
+++ b/src/crashes/crash_manager.rs
@@ -75,7 +75,7 @@ impl CrashManager {
             .latest_version(organization.to_string(), application.to_string())
             .expect("Missing version json.");
         let versions = VersionListParser::versions(&latest_version_json).unwrap();
-        let mut latest_version;
+        let latest_version;
         match distribution_group {
             Some(group) => latest_version = VersionList::latest_version_of_distribution_group(versions, group),
             None        => latest_version = VersionList::latest_version(versions)

--- a/src/crashes/crash_manager.rs
+++ b/src/crashes/crash_manager.rs
@@ -75,10 +75,9 @@ impl CrashManager {
             .latest_version(organization.to_string(), application.to_string())
             .expect("Missing version json.");
         let versions = VersionListParser::versions(&latest_version_json).unwrap();
-        let latest_version;
-        match distribution_group {
-            Some(group) => latest_version = VersionList::latest_version_of_distribution_group(versions, group),
-            None        => latest_version = VersionList::latest_version(versions)
+        let latest_version = match distribution_group {
+            Some(group) => VersionList::latest_version_of_distribution_group(versions, group),
+            None        => VersionList::latest_version(versions)
         };
 
         match latest_version {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ impl CrashReporter {
         organization: &str,
         application: &str,
         version: Option<String>,
-        distribution_group: Option<&str>,
+        distribution_group: Option<String>,
     ) -> CrashReporter {
         CrashReporter {
             token: token.to_string(),
@@ -50,7 +50,7 @@ impl CrashReporter {
             version: version.map(|s| s.to_string()),
             file_writer: &FileWriter {},
             printer: &StdOutPrinter {},
-            distribution_group: distribution_group.map(|s| s.to_string()),
+            distribution_group: distribution_group,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub struct CrashReporter {
     organization: String,
     application: String,
     version: Option<String>,
+    distribution_group: Option<String>,
     file_writer: &'static dyn Writing,
     printer: &'static dyn Printing,
 }
@@ -40,6 +41,7 @@ impl CrashReporter {
         organization: &str,
         application: &str,
         version: Option<String>,
+        distribution_group: Option<&str>,
     ) -> CrashReporter {
         CrashReporter {
             token: token.to_string(),
@@ -48,6 +50,7 @@ impl CrashReporter {
             version: version.map(|s| s.to_string()),
             file_writer: &FileWriter {},
             printer: &StdOutPrinter {},
+            distribution_group: distribution_group.map(|s| s.to_string()),
         }
     }
 
@@ -157,6 +160,7 @@ This report was created using `recrep` for {{organization}}/{{application}}/{{ve
             self.organization.as_str(),
             self.application.as_str(),
             self.version.clone(),
+            self.distribution_group.clone(),
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,8 @@ impl CrashReporter {
     ///```
     /// use recrep::CrashReporter;
     ///
-    /// let reporter = CrashReporter::with_token("abc", "org", "app", Some("1.2.3".to_string()));
+    /// let reporter = CrashReporter::with_token("abc", "org", "app", Some("1.2.3".to_string()),
+    /// None);
     ///
     /// assert_eq!("abc", reporter.token);
     /// ```
@@ -69,7 +70,7 @@ impl CrashReporter {
     /// # use recrep::model::Report;
     /// #
     /// # let crash_list = TestHelper::crash_list_from_json("src/json_parsing/test_fixtures/two_crashes.json");
-    /// let reporter = CrashReporter::with_token("abc", "org name", "app id", None);
+    /// let reporter = CrashReporter::with_token("abc", "org name", "app id", None, None);
     /// let report = Report::new("version".to_string(), crash_list);
     /// reporter.report(report, None)
     /// ```
@@ -89,7 +90,7 @@ impl CrashReporter {
     /// # use recrep::utils::test_helper::TestHelper;
     /// # use recrep::CrashReporter;
     /// #
-    /// let reporter = CrashReporter::with_token("abc", "org name", "app id", None);
+    /// let reporter = CrashReporter::with_token("abc", "org name", "app id", None, None);
     /// let report = TestHelper::report_from_json("src/json_parsing/test_fixtures/two_crashes.json");
     /// let formatted_report = reporter.format_report(report);
     /// assert_eq!(formatted_report.chars().count(), 1100)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ impl CrashReporter {
     /// use recrep::CrashReporter;
     ///
     /// let reporter = CrashReporter::with_token("abc", "org", "app", Some("1.2.3".to_string()),
-    /// None);
+    /// Some("My-Distribution-Group".to_string()));
     ///
     /// assert_eq!("abc", reporter.token);
     /// ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,10 @@ fn main() {
     let outfile = matches.value_of("outfile");
     let organization = matches.value_of("organization").unwrap();
     let application = matches.value_of("application").unwrap();
+    let distribution_group = matches.value_of("distribution-group");
 
     let v = version.map(|s| s.to_string());
-    let crash_reporter = CrashReporter::with_token(token, organization, application, v);
+    let crash_reporter = CrashReporter::with_token(token, organization, application, v, distribution_group);
     crash_reporter.create_report(outfile);
 }
 
@@ -58,6 +59,12 @@ fn matches_for_app<'a>(app: App<'a, '_>) -> ArgMatches<'a> {
             .takes_value(true)
             .short("o")
             .long("outfile")
+            .required(false),
+        Arg::with_name("distribution-group")
+            .help("Distribution group used to search for the latest version released into this distribution group")
+            .takes_value(true)
+            .short("g")
+            .long("group")
             .required(false),
     ])
     .get_matches()

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,13 +11,13 @@ fn main() {
     let token = matches.value_of("token").expect("Token is required.");
     let version = matches.value_of("version");
     let outfile = matches.value_of("outfile");
-    let organization = matches.value_of("organization").unwrap();
-    let application = matches.value_of("application").unwrap();
+    let organization = matches.value_of("organization").expect("Organization is required");
+    let application = matches.value_of("application").expect("Application is required");
     let distribution_group = matches.value_of("distribution-group");
 
-    let v = version.map(|s| s.to_string());
-    let group  = distribution_group.map(|s| s.to_string());
-    let crash_reporter = CrashReporter::with_token(token, organization, application, v, group);
+    let version = version.map(String::from);
+    let group  = distribution_group.map(String::from);
+    let crash_reporter = CrashReporter::with_token(token, organization, application, version, group);
     crash_reporter.create_report(outfile);
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,8 @@ fn main() {
     let distribution_group = matches.value_of("distribution-group");
 
     let v = version.map(|s| s.to_string());
-    let crash_reporter = CrashReporter::with_token(token, organization, application, v, distribution_group);
+    let group  = distribution_group.map(|s| s.to_string());
+    let crash_reporter = CrashReporter::with_token(token, organization, application, v, group);
     crash_reporter.create_report(outfile);
 }
 

--- a/src/model/version.rs
+++ b/src/model/version.rs
@@ -5,4 +5,13 @@ pub struct Version {
     pub short_version: String,
 
     pub uploaded_at: String,
+
+    pub distribution_groups: Option<Vec<DistributionGroup>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DistributionGroup {
+    pub id: String,
+
+    pub name: String,
 }

--- a/src/model/version_list.rs
+++ b/src/model/version_list.rs
@@ -1,4 +1,4 @@
-use crate::model::version::{Version, DistributionGroup};
+use crate::model::version::{DistributionGroup, Version};
 pub struct VersionList {}
 
 impl VersionList {
@@ -14,16 +14,25 @@ impl VersionList {
 
         let group_version = sorted_versions
             .iter()
-            .filter(|version| VersionList::by_distribution_group(&distribution_group,
-                                                                 version.distribution_groups.as_ref()))
+            .filter(|version| {
+                VersionList::by_distribution_group(
+                    &distribution_group,
+                    version.distribution_groups.as_ref(),
+                )
+            })
             .next();
 
         return group_version.cloned();
     }
 
-    fn by_distribution_group(distribution_group: &String, distribution_groups: Option<&Vec<DistributionGroup>>) -> bool {
+    fn by_distribution_group(
+        distribution_group: &String,
+        distribution_groups: Option<&Vec<DistributionGroup>>,
+    ) -> bool {
         match distribution_groups {
-            Some(groups) => groups.iter().any(|group| group.name == distribution_group.to_string()),
+            Some(groups) => groups
+                .iter()
+                .any(|group| group.name == distribution_group.to_string()),
             None => false,
         }
     }
@@ -66,10 +75,9 @@ mod tests {
             None => panic!("There was no latest version in the returned sorted list"),
         }
     }
-    
+
     #[test]
     fn correct_version_when_filtering_by_distribution_group() {
-
         let distribution_group_name = "Test distribution group";
 
         let irrelevant_group = DistributionGroup {
@@ -103,18 +111,22 @@ mod tests {
 
         let vec = vec![version1, version2, version3];
 
-        let found_version = VersionList::latest_version_of_distribution_group(vec, distribution_group_name.to_string());
+        let found_version = VersionList::latest_version_of_distribution_group(
+            vec,
+            distribution_group_name.to_string(),
+        );
+
         match found_version {
-            Some(found_version) => {
-                assert_eq!(found_version.short_version, String::from(expected_version_string))
-            }
+            Some(found_version) => assert_eq!(
+                found_version.short_version,
+                String::from(expected_version_string)
+            ),
             None => panic!("There was no latest version in the returned sorted list"),
         }
     }
 
     #[test]
     fn dont_find_version_when_filtering_by_distribution_group() {
-
         let distribution_group_name = "Test distribution group";
         let other_distribution_group_name = "Another distribution group";
 
@@ -142,12 +154,16 @@ mod tests {
 
         let vec = vec![version1, version2, version3];
 
-        let found_version = VersionList::latest_version_of_distribution_group(vec, distribution_group_name.to_string());
+        let found_version = VersionList::latest_version_of_distribution_group(
+            vec,
+            distribution_group_name.to_string(),
+        );
+
         match found_version {
             Some(_found_version) => {
                 panic!("Should not find any version");
             }
-            None => ()
+            None => (),
         }
     }
 }

--- a/src/model/version_list.rs
+++ b/src/model/version_list.rs
@@ -3,35 +3,32 @@ pub struct VersionList {}
 
 impl VersionList {
     pub fn latest_version(versions: Vec<Version>) -> Option<Version> {
-        let sorted_versions = VersionList::sort_versions(versions);
-        sorted_versions.first().map(|v| v.clone())
+        VersionList::sort_versions(versions)
+            .first()
+            .cloned()
     }
 
     pub fn latest_version_of_distribution_group(versions: Vec<Version>, distribution_group: String) -> Option<Version> {
         let sorted_versions = VersionList::sort_versions(versions);
 
-        for version in sorted_versions.iter() {
+        for version in sorted_versions {
             match &version.distribution_groups {
                 Some(groups) => {
-                    for group in groups.iter() {
-                        if group.name == distribution_group {
-                            return Some(version.clone());
-                        }
+                    if groups.iter().find(|group| group.name == distribution_group).is_some() {
+                        return Some(version.clone());
                     }
                 }
                 None => return None
             }
         }
 
-        return None;
+        None
     }
 
-    fn sort_versions(versions: Vec<Version>) -> Vec<Version> {
-        let mut sorted_versions = versions.to_vec();
-        sorted_versions.sort_by(|a, b| b.uploaded_at.cmp(&a.uploaded_at));
-        return sorted_versions;
+    fn sort_versions(mut versions: Vec<Version>) -> Vec<Version> {
+        versions.sort_by(|a, b| b.uploaded_at.cmp(&a.uploaded_at));
+        versions
     }   
-
 }
 
 #[cfg(test)]

--- a/src/model/version_list.rs
+++ b/src/model/version_list.rs
@@ -57,6 +57,7 @@ mod tests {
             uploaded_at: String::from("2019-11-18T22:29:48.000Z"),
             distribution_groups: None,
         };
+
         let vec = vec![version1, version2, version3];
 
         let latest = VersionList::latest_version(vec);

--- a/src/model/version_list.rs
+++ b/src/model/version_list.rs
@@ -3,10 +3,35 @@ pub struct VersionList {}
 
 impl VersionList {
     pub fn latest_version(versions: Vec<Version>) -> Option<Version> {
-        let mut sorted_versions = versions.to_vec();
-        sorted_versions.sort_by(|a, b| b.uploaded_at.cmp(&a.uploaded_at));
+        let mut sorted_versions = VersionList::sort_versions(versions);
         sorted_versions.first().map(|v| v.clone())
     }
+
+    pub fn latest_version_of_distribution_group(versions: Vec<Version>, distribution_group: String) -> Option<Version> {
+        let mut sorted_versions = VersionList::sort_versions(versions);
+
+        for version in sorted_versions.iter() {
+            match &version.distribution_groups {
+                Some(groups) => {
+                    for group in groups.iter() {
+                        if group.name == distribution_group {
+                            return Some(version.clone());
+                        }
+                    }
+                }
+                None => return None
+            }
+        }
+
+        return None;
+    }
+
+    fn sort_versions(versions: Vec<Version>) -> Vec<Version> {
+        let mut sorted_versions = versions.to_vec();
+        sorted_versions.sort_by(|a, b| b.uploaded_at.cmp(&a.uploaded_at));
+        return sorted_versions;
+    }   
+
 }
 
 #[cfg(test)]

--- a/src/model/version_list.rs
+++ b/src/model/version_list.rs
@@ -3,12 +3,12 @@ pub struct VersionList {}
 
 impl VersionList {
     pub fn latest_version(versions: Vec<Version>) -> Option<Version> {
-        let mut sorted_versions = VersionList::sort_versions(versions);
+        let sorted_versions = VersionList::sort_versions(versions);
         sorted_versions.first().map(|v| v.clone())
     }
 
     pub fn latest_version_of_distribution_group(versions: Vec<Version>, distribution_group: String) -> Option<Version> {
-        let mut sorted_versions = VersionList::sort_versions(versions);
+        let sorted_versions = VersionList::sort_versions(versions);
 
         for version in sorted_versions.iter() {
             match &version.distribution_groups {

--- a/src/model/version_list.rs
+++ b/src/model/version_list.rs
@@ -1,4 +1,4 @@
-use crate::model::Version;
+use crate::model::version::{Version, DistributionGroup};
 pub struct VersionList {}
 
 impl VersionList {
@@ -66,6 +66,94 @@ mod tests {
                 assert_eq!(latest.uploaded_at, String::from("2019-11-18T22:29:48.000Z"))
             }
             None => panic!("There was no latest version in the returned sorted list"),
+        }
+    }
+    
+    #[test]
+    fn correct_version_when_filtering_by_distribution_group() {
+
+        let distribution_group_name = "Test distribution group";
+
+        let irrelevant_group = DistributionGroup {
+            id: String::from("irrelevant_ID"),
+            name: String::from("irrelevant_string"),
+        };
+
+        let relevant_group = DistributionGroup {
+            id: String::from("irrelevant_ID"),
+            name: String::from(distribution_group_name),
+        };
+
+        let expected_version_string = "1.1";
+
+        let version1 = Version {
+            short_version: String::from("1.0"),
+            uploaded_at: String::from("2019-11-16T22:29:48.000Z"),
+            distribution_groups: Some(vec![irrelevant_group.clone()]),
+        };
+
+        let version2 = Version {
+            short_version: String::from(expected_version_string),
+            uploaded_at: String::from("2019-11-17T22:29:48.000Z"),
+            distribution_groups: Some(vec![relevant_group]),
+        };
+        let version3 = Version {
+            short_version: String::from("1.2"),
+            uploaded_at: String::from("2019-11-18T22:29:48.000Z"),
+            distribution_groups: Some(vec![irrelevant_group.clone()]),
+        };
+
+        let vec = vec![version1, version2, version3];
+
+        let found_version = VersionList::latest_version_of_distribution_group(vec, distribution_group_name.to_string());
+        match found_version {
+            Some(found_version) => {
+                assert_eq!(found_version.short_version, String::from(expected_version_string))
+            }
+            None => panic!("There was no latest version in the returned sorted list"),
+        }
+    }
+
+    #[test]
+    fn dont_find_version_when_filtering_by_distribution_group() {
+
+        let distribution_group_name = "Test distribution group";
+        let other_distribution_group_name = "Another distribution group";
+        let relevant_group = DistributionGroup {
+            id: String::from("irrelevant_ID"),
+            name: String::from(distribution_group_name),
+        };
+
+        let group = DistributionGroup {
+            id: String::from("irrelevant_ID"),
+            name: String::from(other_distribution_group_name),
+        };
+
+        let version1 = Version {
+            short_version: String::from("1.0"),
+            uploaded_at: String::from("2019-11-16T22:29:48.000Z"),
+            distribution_groups: Some(vec![group.clone()]),
+        };
+
+        let version2 = Version {
+            short_version: String::from("1.1"),
+            uploaded_at: String::from("2019-11-17T22:29:48.000Z"),
+            distribution_groups: Some(vec![group.clone()]),
+        };
+        let version3 = Version {
+            short_version: String::from("1.2"),
+            uploaded_at: String::from("2019-11-18T22:29:48.000Z"),
+            distribution_groups: Some(vec![group.clone()]),
+        };
+
+        let vec = vec![version1, version2, version3];
+
+        let found_version = VersionList::latest_version_of_distribution_group(vec, distribution_group_name.to_string());
+        match found_version {
+            Some(_found_version) => {
+                panic!("Should not find any version");
+            }
+            None => ()
         }
     }
 }

--- a/src/model/version_list.rs
+++ b/src/model/version_list.rs
@@ -12,22 +12,20 @@ impl VersionList {
     ) -> Option<Version> {
         let sorted_versions = VersionList::sort_versions(versions);
 
-        for version in sorted_versions {
-            match &version.distribution_groups {
-                Some(groups) => {
-                    if groups
-                        .iter()
-                        .find(|group| group.name == distribution_group)
-                        .is_some()
-                    {
-                        return Some(version.clone());
-                    }
-                }
-                None => return None,
-            }
-        }
+        let group_version = sorted_versions
+            .iter()
+            .filter(|version| VersionList::by_distribution_group(&distribution_group,
+                                                                 version.distribution_groups.as_ref()))
+            .next();
 
-        None
+        return group_version.cloned();
+    }
+
+    fn by_distribution_group(distribution_group: &String, distribution_groups: Option<&Vec<DistributionGroup>>) -> bool {
+        match distribution_groups {
+            Some(groups) => groups.iter().any(|group| group.name == distribution_group.to_string()),
+            None => false,
+        }
     }
 
     fn sort_versions(mut versions: Vec<Version>) -> Vec<Version> {
@@ -119,10 +117,6 @@ mod tests {
 
         let distribution_group_name = "Test distribution group";
         let other_distribution_group_name = "Another distribution group";
-        let relevant_group = DistributionGroup {
-            id: String::from("irrelevant_ID"),
-            name: String::from(distribution_group_name),
-        };
 
         let group = DistributionGroup {
             id: String::from("irrelevant_ID"),

--- a/src/model/version_list.rs
+++ b/src/model/version_list.rs
@@ -37,9 +37,9 @@ mod tests {
 
     #[test]
     fn correct_sorting_of_version_list() {
-        let version1 = Version { short_version: String::from("1.0"), uploaded_at: String::from("2019-11-16T22:29:48.000Z") };
-        let version2 = Version { short_version: String::from("1.0"), uploaded_at: String::from("2019-11-17T22:29:48.000Z") };
-        let version3 = Version { short_version: String::from("1.0"), uploaded_at: String::from("2019-11-18T22:29:48.000Z") };
+        let version1 = Version { short_version: String::from("1.0"), uploaded_at: String::from("2019-11-16T22:29:48.000Z"), distribution_groups: None};
+        let version2 = Version { short_version: String::from("1.0"), uploaded_at: String::from("2019-11-17T22:29:48.000Z"), distribution_groups: None};
+        let version3 = Version { short_version: String::from("1.0"), uploaded_at: String::from("2019-11-18T22:29:48.000Z"), distribution_groups: None};
         let mut vec = Vec::new();
 
         vec.push(version1);

--- a/src/model/version_list.rs
+++ b/src/model/version_list.rs
@@ -3,22 +3,27 @@ pub struct VersionList {}
 
 impl VersionList {
     pub fn latest_version(versions: Vec<Version>) -> Option<Version> {
-        VersionList::sort_versions(versions)
-            .first()
-            .cloned()
+        VersionList::sort_versions(versions).first().cloned()
     }
 
-    pub fn latest_version_of_distribution_group(versions: Vec<Version>, distribution_group: String) -> Option<Version> {
+    pub fn latest_version_of_distribution_group(
+        versions: Vec<Version>,
+        distribution_group: String,
+    ) -> Option<Version> {
         let sorted_versions = VersionList::sort_versions(versions);
 
         for version in sorted_versions {
             match &version.distribution_groups {
                 Some(groups) => {
-                    if groups.iter().find(|group| group.name == distribution_group).is_some() {
+                    if groups
+                        .iter()
+                        .find(|group| group.name == distribution_group)
+                        .is_some()
+                    {
                         return Some(version.clone());
                     }
                 }
-                None => return None
+                None => return None,
             }
         }
 
@@ -28,7 +33,7 @@ impl VersionList {
     fn sort_versions(mut versions: Vec<Version>) -> Vec<Version> {
         versions.sort_by(|a, b| b.uploaded_at.cmp(&a.uploaded_at));
         versions
-    }   
+    }
 }
 
 #[cfg(test)]
@@ -37,19 +42,29 @@ mod tests {
 
     #[test]
     fn correct_sorting_of_version_list() {
-        let version1 = Version { short_version: String::from("1.0"), uploaded_at: String::from("2019-11-16T22:29:48.000Z"), distribution_groups: None};
-        let version2 = Version { short_version: String::from("1.0"), uploaded_at: String::from("2019-11-17T22:29:48.000Z"), distribution_groups: None};
-        let version3 = Version { short_version: String::from("1.0"), uploaded_at: String::from("2019-11-18T22:29:48.000Z"), distribution_groups: None};
-        let mut vec = Vec::new();
-
-        vec.push(version1);
-        vec.push(version2);
-        vec.push(version3);
+        let version1 = Version {
+            short_version: String::from("1.0"),
+            uploaded_at: String::from("2019-11-16T22:29:48.000Z"),
+            distribution_groups: None,
+        };
+        let version2 = Version {
+            short_version: String::from("1.0"),
+            uploaded_at: String::from("2019-11-17T22:29:48.000Z"),
+            distribution_groups: None,
+        };
+        let version3 = Version {
+            short_version: String::from("1.0"),
+            uploaded_at: String::from("2019-11-18T22:29:48.000Z"),
+            distribution_groups: None,
+        };
+        let vec = vec![version1, version2, version3];
 
         let latest = VersionList::latest_version(vec);
         match latest {
-            Some(latest) => assert_eq!(latest.uploaded_at, String::from("2019-11-18T22:29:48.000Z")),
-            None => panic!("There was no latest version in the returned sorted list")
+            Some(latest) => {
+                assert_eq!(latest.uploaded_at, String::from("2019-11-18T22:29:48.000Z"))
+            }
+            None => panic!("There was no latest version in the returned sorted list"),
         }
     }
 }


### PR DESCRIPTION
This pull request adds support for specifying an AppCenter distribution group. This allows more fine-grained specification of retrieving version related crash reports.
The main behavior is unchanged, meaning the same endpoint is used to retrieve version information, but the specified distribution group is used to only consider this particular distribution group and omit all other version information.