### PR TITLE
Fix warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,8 @@ pub struct CrashReporter {
     organization: String,
     application: String,
     version: Option<String>,
-    file_writer: &'static Writing,
-    printer: &'static Printing,
+    file_writer: &'static dyn Writing,
+    printer: &'static dyn Printing,
 }
 
 impl CrashReporter {


### PR DESCRIPTION
This pull request updates 2 parameters to use the new `dyn` Syntax. Find more information about the `dyn` keyword on [doc.rust-lang.org](https://doc.rust-lang.org/edition-guide/rust-2018/trait-system/dyn-trait-for-trait-objects.html).