### PR TITLE
Add Support for Start Date

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,13 @@ reqwest = "~0.9.12"
 # Rust templating with Handlebars
 # https://github.com/sunng87/handlebars-rust
 handlebars = "~1.1.0"
+
+# Chrono: Date and Time for Rust
+# https://github.com/chronotope/chrono
+chrono = "~0.4"
+
+[dev-dependencies]
+
+# Regex: An implementation of regular expressions for Rust
+# https://github.com/rust-lang/regex
+regex = "~1.0"

--- a/src/api/api_mock.rs
+++ b/src/api/api_mock.rs
@@ -45,6 +45,7 @@ impl API for MockAPI {
         _organization: String,
         _application: String,
         _version: String,
+        _start_date: String,
     ) -> Result<String, &'static str> {
         match self.crashes.clone() {
             Some(json) => Ok(json),

--- a/src/api/api_trait.rs
+++ b/src/api/api_trait.rs
@@ -23,5 +23,6 @@ pub trait API {
         organization: String,
         application: String,
         version: String,
+        start_date: String,
     ) -> Result<String, &'static str>;
 }

--- a/src/api/appcenter_api.rs
+++ b/src/api/appcenter_api.rs
@@ -52,8 +52,9 @@ impl API for AppCenter {
         organization: String,
         application: String,
         version: String,
+        start_date: String,
     ) -> Result<String, &'static str> {
-        let url = format!("https://api.appcenter.ms/{}/apps/{}/{}/errors/errorGroups?version={}&%24orderby=count%20desc&%24top=20", API_VERSION, organization, application, version);
+        let url = format!("https://api.appcenter.ms/{}/apps/{}/{}/errors/errorGroups?start={}&%24version={}&%24orderby=count%20desc&%24top=20", API_VERSION, organization, application, start_date, version);
         let response = self
             .client
             .get(&url)

--- a/src/crashes/crash_manager.rs
+++ b/src/crashes/crash_manager.rs
@@ -19,7 +19,7 @@ impl CrashManager {
     /// #
     /// // api is a mock that returns 2 crashes
     /// let manager = CrashManager{};
-    /// let report = manager.crash_list(&api, "org", "app", Some("1.2.3".to_string()), None).unwrap();
+    /// let report = manager.crash_list(&api, "org", "app", Some("1.2.3".to_string()), None, None).unwrap();
     ///
     /// assert_eq!(report.crash_list.crashes.len(), 2);
     /// assert_eq!(report.version, "1.2.3");

--- a/src/crashes/crash_manager.rs
+++ b/src/crashes/crash_manager.rs
@@ -115,3 +115,21 @@ impl CrashManager {
         }
     }
 }
+
+#[test]
+fn test_default_start_date() {
+    use regex::Regex;
+    let re = Regex::new(r"^\d{4}-\d{2}-\d{2}$").unwrap();
+    let crash_manager = CrashManager {};
+    assert!(re.is_match(crash_manager.default_start_date().as_str()));
+}
+
+#[test]
+fn test_date_string_from_date() {
+    use chrono::{NaiveDate, NaiveDateTime};
+
+    let crash_manager = CrashManager {};
+    let naive_date_time: NaiveDateTime = NaiveDate::from_ymd(2019, 7, 25).and_hms(8, 47, 0);
+    let date = DateTime::<Utc>::from_utc(naive_date_time, Utc);
+    assert_eq!("2019-07-25", crash_manager.date_string_from_date(date))
+}

--- a/src/crashes/crash_manager.rs
+++ b/src/crashes/crash_manager.rs
@@ -2,6 +2,7 @@ use crate::api::API;
 use crate::json_parsing::crash_parsing::CrashParser;
 use crate::json_parsing::version_parsing::VersionListParser;
 use crate::model::{Report, VersionList};
+use chrono::{DateTime, Datelike, Duration, Utc};
 
 /// The `CrashManager` is responsible to get crash data from its API.
 /// It transforms crash data into structs using a the `CrashParser`.
@@ -30,21 +31,39 @@ impl CrashManager {
         application: &str,
         version: Option<String>,
         distribution_group: Option<String>,
+        start_date: Option<String>,
     ) -> Result<Report, &'static str> {
+        let start_date = start_date.unwrap_or(self.default_start_date());
         match version {
             Some(version) => self.crash_list_for_version(
                 api,
                 organization.to_string(),
                 application.to_string(),
                 version,
+                start_date,
             ),
             None => self.crash_list_for_latest_version(
                 api,
                 organization.to_string(),
                 application.to_string(),
                 distribution_group,
+                start_date,
             ),
         }
+    }
+
+    /// The default start date since the first occurrence of any crash to retrieve from the API.
+    ///
+    /// This defaults to 90 days.
+    fn default_start_date(&self) -> String {
+        let now = Utc::now() - Duration::days(90);
+        self.date_string_from_date(now)
+    }
+
+    /// Create a formatted date string from a given date
+    fn date_string_from_date(&self, date: DateTime<Utc>) -> String {
+        let (_, year) = date.year_ce();
+        format!("{}-{:02}-{:02}", year, date.month(), date.day())
     }
 
     /// Returns a Report after loading and parsing crashes json from the API
@@ -54,8 +73,9 @@ impl CrashManager {
         organization: String,
         application: String,
         version: String,
+        start_date: String,
     ) -> Result<Report, &'static str> {
-        match api.crashes_json(organization, application, version.clone()) {
+        match api.crashes_json(organization, application, version.clone(), start_date) {
             Ok(json) => Ok(Report::new(
                 version,
                 CrashParser::crash_list_from_json(json.as_str()).unwrap(),
@@ -70,6 +90,7 @@ impl CrashManager {
         organization: String,
         application: String,
         distribution_group: Option<String>,
+        start_date: String,
     ) -> Result<Report, &'static str> {
         let latest_version_json = api
             .latest_version(organization.to_string(), application.to_string())
@@ -86,6 +107,7 @@ impl CrashManager {
                 organization.to_string(),
                 application.to_string(),
                 latest_version.short_version.clone(),
+                start_date,
             ),
             None => {
                 Err("💥 Failed to get the latest version. Cannot get crashes without a version.")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub struct CrashReporter {
     application: String,
     version: Option<String>,
     distribution_group: Option<String>,
+    start_date: Option<String>,
     file_writer: &'static dyn Writing,
     printer: &'static dyn Printing,
 }
@@ -43,6 +44,7 @@ impl CrashReporter {
         application: &str,
         version: Option<String>,
         distribution_group: Option<String>,
+        start_date: Option<String>,
     ) -> CrashReporter {
         CrashReporter {
             token: token.to_string(),
@@ -52,6 +54,7 @@ impl CrashReporter {
             file_writer: &FileWriter {},
             printer: &StdOutPrinter {},
             distribution_group: distribution_group,
+            start_date: start_date,
         }
     }
 
@@ -162,6 +165,7 @@ This report was created using `recrep` for {{organization}}/{{application}}/{{ve
             self.application.as_str(),
             self.version.clone(),
             self.distribution_group.clone(),
+            self.start_date.clone(),
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ impl CrashReporter {
     ///```
     /// use recrep::CrashReporter;
     ///
-    /// let reporter = CrashReporter::with_token("abc", "org", "app", Some("1.2.3".to_string()),
+    /// let reporter = CrashReporter::with_token("abc", "org", "app", Some("1.2.3".to_string()), None,
     /// Some("My-Distribution-Group".to_string()));
     ///
     /// assert_eq!("abc", reporter.token);
@@ -73,7 +73,7 @@ impl CrashReporter {
     /// # use recrep::model::Report;
     /// #
     /// # let crash_list = TestHelper::crash_list_from_json("src/json_parsing/test_fixtures/two_crashes.json");
-    /// let reporter = CrashReporter::with_token("abc", "org name", "app id", None, None);
+    /// let reporter = CrashReporter::with_token("abc", "org name", "app id", None, None, None);
     /// let report = Report::new("version".to_string(), crash_list);
     /// reporter.report(report, None)
     /// ```
@@ -93,7 +93,7 @@ impl CrashReporter {
     /// # use recrep::utils::test_helper::TestHelper;
     /// # use recrep::CrashReporter;
     /// #
-    /// let reporter = CrashReporter::with_token("abc", "org name", "app id", None, None);
+    /// let reporter = CrashReporter::with_token("abc", "org name", "app id", None, None, None);
     /// let report = TestHelper::report_from_json("src/json_parsing/test_fixtures/two_crashes.json");
     /// let formatted_report = reporter.format_report(report);
     /// assert_eq!(formatted_report.chars().count(), 1100)

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,10 +14,13 @@ fn main() {
     let organization = matches.value_of("organization").expect("Organization is required");
     let application = matches.value_of("application").expect("Application is required");
     let distribution_group = matches.value_of("distribution-group");
+    let start_date = matches.value_of("start-date");
 
     let version = version.map(String::from);
-    let group  = distribution_group.map(String::from);
-    let crash_reporter = CrashReporter::with_token(token, organization, application, version, group);
+    let group = distribution_group.map(String::from);
+    let start_date = start_date.map(String::from);
+    let crash_reporter =
+        CrashReporter::with_token(token, organization, application, version, group, start_date);
     crash_reporter.create_report(outfile);
 }
 
@@ -66,6 +69,12 @@ fn matches_for_app<'a>(app: App<'a, '_>) -> ArgMatches<'a> {
             .takes_value(true)
             .short("g")
             .long("group")
+            .required(false),
+        Arg::with_name("from")
+            .help("The start date from when crashes should be included in the report.")
+            .takes_value(true)
+            .short("f")
+            .long("from")
             .required(false),
     ])
     .get_matches()

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ fn matches_for_app<'a>(app: App<'a, '_>) -> ArgMatches<'a> {
             .long("outfile")
             .required(false),
         Arg::with_name("distribution-group")
-            .help("Distribution group used to search for the latest version released into this distribution group")
+            .help("Distribution group used to search for the latest version released into this distribution group.")
             .takes_value(true)
             .short("g")
             .long("group")


### PR DESCRIPTION
This pull request adds support for the `start` parameter of [errors/Errors_GroupList](https://openapi.appcenter.ms/#/errors/Errors_GroupList).

## Motivation

I was checking an old version of an application for crashes and it didn't show any. I understood that the AppCenter API would not return the crashes because they were apparently not occurring in the time window the API searches for crashes.

After adding this parameter and using it in an example app I am working on I was eventually able to see my crashes.