### PR TITLE
Release 2894/filter out errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "recrep"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["The Mobile Releases Team of XING SE <mobile_releases@xing.com>"]
 edition = "2018"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ impl CrashReporter {
     pub fn format_report(&self, report: Report) -> String {
         let mut crash_list_json: serde_json::Value = json!(report.crash_list);
         let data = crash_list_json.as_object_mut().unwrap();
-        
+
         if self.filter_out_errors {
             self.filter_out_errors(data);
         }
@@ -271,10 +271,7 @@ This report was created using `recrep` for {{organization}}/{{application}}/{{ve
         }
     }
 
-    fn filter_out_errors(
-        &self,
-        crash_data: &mut serde_json::Map<String, serde_json::Value>,
-    ) {
+    fn filter_out_errors(&self, crash_data: &mut serde_json::Map<String, serde_json::Value>) {
         let value = &mut crash_data["errorGroups"];
         let all_crashes: &mut Vec<serde_json::Value> = value.as_array_mut().unwrap();
         // exceptionAppCode is set to true on crashes and false on errors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -471,16 +471,12 @@ fn test_report_formatting_supports_filtering_out_errors() {
 
     let mut crash_list_json: serde_json::Value = json!(report.crash_list);
     let data = crash_list_json.as_object_mut().unwrap();
-    let amount_of_crashes_in_fixture = data.get("errorGroups")
-                                           .unwrap()
-                                           .as_array()
-                                           .unwrap().len();
+    let amount_of_crashes_in_fixture = data.get("errorGroups").unwrap().as_array().unwrap().len();
 
     let formatted_report = reporter.format_report(report);
     let amount_of_formatted_crashes = formatted_report.matches("More on AppCenter").count();
     assert!(amount_of_crashes_in_fixture != amount_of_formatted_crashes);
 }
-
 
 #[test]
 fn test_report_formatting_does_not_filter_out_errors() {
@@ -501,10 +497,7 @@ fn test_report_formatting_does_not_filter_out_errors() {
 
     let mut crash_list_json: serde_json::Value = json!(report.crash_list);
     let data = crash_list_json.as_object_mut().unwrap();
-    let amount_of_crashes_in_fixture = data.get("errorGroups")
-                                           .unwrap()
-                                           .as_array()
-                                           .unwrap().len();
+    let amount_of_crashes_in_fixture = data.get("errorGroups").unwrap().as_array().unwrap().len();
 
     let formatted_report = reporter.format_report(report);
     let amount_of_formatted_crashes = formatted_report.matches("More on AppCenter").count();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,10 +277,8 @@ This report was created using `recrep` for {{organization}}/{{application}}/{{ve
     ) {
         let value = &mut crash_data["errorGroups"];
         let all_crashes: &mut Vec<serde_json::Value> = value.as_array_mut().unwrap();
-        println!("len: {}", all_crashes.len());
         // exceptionAppCode is set to true on crashes and false on errors
         all_crashes.retain(|crash| crash["exceptionAppCode"] == true);
-        println!("len: {}", all_crashes.len());
     }
 
     fn add_operating_system_information(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ impl CrashReporter {
     /// use recrep::CrashReporter;
     ///
     /// let reporter = CrashReporter::with_token("abc", "org", "app", Some("1.2.3".to_string()),
-    /// Some("My-Distribution-Group".to_string()), None, false, false);
+    /// Some("My-Distribution-Group".to_string()), None, false, false, false);
     ///
     /// assert_eq!("abc", reporter.token);
     /// ```
@@ -91,7 +91,7 @@ impl CrashReporter {
     /// #
     /// # let crash_list = TestHelper::crash_list_from_json("src/json_parsing/test_fixtures/two_crashes.json");
     /// let reporter = CrashReporter::with_token("abc", "org name", "app id", None, None, None,
-    /// false, false);
+    /// false, false, false);
     /// let report = Report::new("version".to_string(), crash_list);
     /// reporter.write_report(report, None)
     /// ```
@@ -112,7 +112,7 @@ impl CrashReporter {
     /// # use recrep::CrashReporter;
     /// #
     /// let reporter = CrashReporter::with_token("abc", "org name", "app id", None, None, None,
-    /// false, false);
+    /// false, false, false);
     /// let report = TestHelper::report_from_json("src/json_parsing/test_fixtures/two_crashes.json");
     /// let formatted_report = reporter.format_report(report);
     /// assert_eq!(formatted_report.chars().count(), 1352)
@@ -416,6 +416,7 @@ fn test_report_formatting_supports_threshold() {
         Some(300),
         false,
         false,
+        false,
     );
     let report = utils::test_helper::TestHelper::report_from_json(
         "src/json_parsing/test_fixtures/two_crashes.json",
@@ -433,6 +434,7 @@ fn test_report_template_if_no_crash_exists() {
         None,
         None,
         Some(300),
+        false,
         false,
         false,
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,6 +274,7 @@ This report was created using `recrep` for {{organization}}/{{application}}/{{ve
     fn filter_out_errors(&self, crash_data: &mut serde_json::Map<String, serde_json::Value>) {
         let value = &mut crash_data["errorGroups"];
         let all_crashes: &mut Vec<serde_json::Value> = value.as_array_mut().unwrap();
+
         // exceptionAppCode is set to true on crashes and false on errors
         all_crashes.retain(|crash| crash["exceptionAppCode"] == true);
     }
@@ -423,6 +424,32 @@ fn test_report_formatting_supports_threshold() {
     );
     let formatted_report = reporter.format_report(report);
     assert_eq!(formatted_report.chars().count(), 1412)
+}
+
+#[test]
+fn test_report_formatting_supports_filtering_out_errors() {
+    let reporter = CrashReporter::with_token(
+        "abc",
+        "org name",
+        "app id",
+        None,
+        None,
+        Some(300),
+        false,
+        false,
+        true,
+    );
+    let report = utils::test_helper::TestHelper::report_from_json(
+        "src/json_parsing/test_fixtures/crashes.json",
+    );
+
+    let mut crash_list_json: serde_json::Value = json!(report.crash_list);
+    let data = crash_list_json.as_object_mut().unwrap();
+    reporter.filter_out_errors(data);
+
+    let value = &mut data["errorGroups"];
+    let all_crashes: &mut Vec<serde_json::Value> = value.as_array_mut().unwrap();
+    assert_eq!(all_crashes.len(), 26);
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
     let distribution_group = matches.value_of("distribution-group");
     let crash_threshold = matches.value_of("threshold");
     let use_arithmetic_mean = matches.is_present("arithmetic-mean");
-
+    let filter_out_errors = matches.is_present("omit-errors");
     let version = version.map(String::from);
     let group = distribution_group.map(String::from);
     let crash_threshold =
@@ -32,6 +32,7 @@ fn main() {
         crash_threshold,
         use_arithmetic_mean,
         show_os_information,
+        filter_out_errors,
     );
     crash_reporter.create_report(outfile);
 }
@@ -98,6 +99,11 @@ fn matches_for_app<'a>(app: App<'a, '_>) -> ArgMatches<'a> {
             .help("Show the operating systems affected for each crash.")
             .takes_value(false)
             .long("show-operating-systems")
+            .required(false),
+        Arg::with_name("omit-errors")
+            .help("Filters out AppCenter \"Crashes\" that are classified as `Error`.")
+            .takes_value(false)
+            .long("omit-errors")
             .required(false),
     ])
     .get_matches()

--- a/src/model/crash.rs
+++ b/src/model/crash.rs
@@ -27,6 +27,9 @@ pub struct Crash {
     #[serde(rename = "deviceCount")]
     pub device_count: Option<u64>,
 
+    #[serde(rename = "exceptionAppCode")]
+    pub exception_app_code: Option<bool>,
+
     pub count: Option<u64>,
 
     pub operating_systems: Option<Vec<OperatingSystemCount>>,


### PR DESCRIPTION
This pull request allows for filtering out "crashes" that are mere `errors`. While this sounds weird, AppCenter classifies crashes into actual crashes and errors. `Errors` are considered non-fatal and may or may not be relevant to consider for a crash report.
Thus, the pull request adds a CLI flag called `--omit-errors` that makes recrep remove those crashes that are classified as `errors`.